### PR TITLE
Added discordisteam.com

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -28,6 +28,7 @@ discorcl.gift
 discorcl.link
 discorclapp.com
 discorclapp.fun
+discorclgift.com
 discord-air.xyz
 discord-airdrop.com
 discord-app.me
@@ -78,7 +79,6 @@ discords-nitro.xyz
 discordsteams.com
 discorid.gift
 discorl.com
-discorclgift.com
 discrod-gift.com
 discrod.gifts
 discrodapp.ru


### PR DESCRIPTION
Bit.ly link redirects to http://discordisteam.com/airdrop.

Screenshoots: 
https://preview.redd.it/b1nwd0d3qnx71.jpg?width=640&height=921&crop=smart&auto=webp&s=db885d506d012194901a2052bc06068f11fde397
https://preview.redd.it/y4zcl0d3qnx71.jpg?width=640&height=982&crop=smart&auto=webp&s=d74cb50ac34c379314a397ce533bcd08fb721983
![image](https://user-images.githubusercontent.com/42188518/140576976-3083a7bb-f902-4ac2-bd55-713e6bf40a86.png)
